### PR TITLE
Add font-awesome icons for 'our services' section

### DIFF
--- a/app/assets/stylesheets/welcome.scss
+++ b/app/assets/stylesheets/welcome.scss
@@ -30,6 +30,12 @@ h1{
 .main-image {
 }
 
+// Classes
+.center-block {
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+}
 
 
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,6 +6,7 @@
   <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
   <%= csrf_meta_tags %>
   <link href='http://fonts.googleapis.com/css?family=Nunito' rel='stylesheet' type='text/css'>
+  <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
 </head>
 <body>
 

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -15,17 +15,23 @@
       <div class="col-sm-8 col-sm-offset-2">
         <div class="row">
           <div class="col-sm-4 service-offering">
-            <%= image_tag "computer.png", alt: "Computer Icon",  class: "img-responsive"  %>
+            <div class="text-center">
+              <i class="fa fa-laptop" style="font-size: 15em;"></i>                      
+            </div>
             <h3>Web</h3>
             <p>Here is a bunch of text about our web services</p>
           </div>
           <div class="col-sm-4 service-offering">
-            <%= image_tag "phone.png", alt: "Phone Icon",  class: "img-responsive"  %>
-            <h3>Mobil</h3>
+            <div class="text-center">
+              <i class="fa fa-mobile" style="font-size: 15em;"></i>                      
+            </div>
+            <h3>Mobile</h3>
             <p>Here is a bunch of text about our mobil services</p>
           </div>
           <div class="col-sm-4 service-offering">
-            <%= image_tag "person.png", alt: "Person Icon",  class: "img-responsive"  %>
+            <div class="text-center">
+              <i class="fa fa-user" style="font-size: 15em;"></i>                      
+            </div>
             <h3>Consulting</h3>
             <p>Here is a bunch of text about our consulting services</p>
           </div>


### PR DESCRIPTION
Used CDN as opposed to manually adding assets.  Relives us of managing image assets for the three "Our Services" icons.  @ryandorr17 
